### PR TITLE
Updated "name" type for a <Icon /> component

### DIFF
--- a/src/components/action.tsx
+++ b/src/components/action.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import {View, Text, Colors} from 'react-native-ui-lib';
 import {Bounceable} from 'rn-bounceable';
-import {Icon} from './icon';
+import {Icon, IconName} from './icon';
 
 type ActionProps = {
   title: string;
-  icon?: string;
-  rightIcon?: string;
+  icon?: IconName;
+  rightIcon?: IconName;
   info?: string;
   disabled?: boolean;
   onPress?: () => void;

--- a/src/components/icon.tsx
+++ b/src/components/icon.tsx
@@ -3,8 +3,10 @@ import {View, Colors, ViewProps} from 'react-native-ui-lib';
 import {Ionicons} from '@expo/vector-icons';
 import {Bounceable} from 'rn-bounceable';
 
+export type IconName = keyof typeof Ionicons.glyphMap;
+
 type IconProps = {
-  name: string;
+  name: IconName;
   size?: number;
   color?: string;
   viewProps?: ViewProps;
@@ -26,7 +28,7 @@ export const Icon: React.FC<IconProps> = ({
   const Icon = useMemo(
     () => (
       <View {...viewProps}>
-        <IconComponent name={name as any} size={size} color={color} />
+        <IconComponent name={name} size={size} color={color} />
       </View>
     ),
     [viewProps, name, size, color],

--- a/src/screens/playground/index.tsx
+++ b/src/screens/playground/index.tsx
@@ -9,7 +9,7 @@ import {useStores} from '@app/stores';
 import {useServices} from '@app/services';
 import {useAppearance} from '@app/utils/hooks';
 import {Row} from '@app/components/row';
-import {Icon} from '@app/components/icon';
+import {Icon, IconName} from '@app/components/icon';
 import {Section} from '@app/components/section';
 import {Alert} from 'react-native';
 
@@ -17,7 +17,7 @@ type SectionData = {
   content: {
     title: string;
     subtitle?: string;
-    icon: string;
+    icon: IconName;
     onPress: PureFunc;
   }[];
 };

--- a/src/utils/designSystem.tsx
+++ b/src/utils/designSystem.tsx
@@ -7,7 +7,7 @@ import {Appearance as RNAppearance, Platform} from 'react-native';
 import {Colors, Typography} from 'react-native-ui-lib';
 
 import {stores} from '@app/stores';
-import {Icon} from '@app/components/icon';
+import {Icon, IconName} from '@app/components/icon';
 import {Appearance} from '@app/utils/types/enums';
 
 // =============
@@ -164,7 +164,7 @@ export const getTabBarIcon =
   ({focused, color, size}: {focused: boolean; color: string; size: number}) =>
     <Icon name={getTabIconName(tabName, focused)} size={size} color={color} />;
 
-const getTabIconName = (tabName: string, focused: boolean): string => {
+const getTabIconName = (tabName: string, focused: boolean): IconName => {
   if (tabName === 'MainTab') {
     return focused ? 'home' : 'home-outline';
   }


### PR DESCRIPTION
Motivation: impove DX and specify types instead of using `as Any`
Description: `as Any` was removed due to autocompletition lost with `<Icon name={string}/>` usages. 
